### PR TITLE
Enhance configuration handling with extensions support

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,9 +14,10 @@ import (
 
 // MCPClientConfig is the configuration used in NewMCPClient
 type MCPClientConfig struct {
-	Command string            `yaml:"command" json:"command"`
-	Args    []string          `yaml:"args" json:"args"`
-	Env     map[string]string `yaml:"env" json:"env"`
+	Command    string            `yaml:"command" json:"command"`
+	Args       []string          `yaml:"args" json:"args"`
+	Env        map[string]string `yaml:"env" json:"env"`
+	Extensions *Extensions       `yaml:"_extensions" json:"_extensions"`
 }
 
 // LoadConfig loads the configuration file from the specified path
@@ -58,9 +59,10 @@ func LoadConfig(path string) (*Config, error) {
 // ConvertToMCPClientConfig converts ServerConfig to MCPClientConfig
 func ConvertToMCPClientConfig(serverCfg ServerConfig) *MCPClientConfig {
 	return &MCPClientConfig{
-		Command: serverCfg.Command,
-		Args:    serverCfg.Args,
-		Env:     serverCfg.Env,
+		Command:    serverCfg.Command,
+		Args:       serverCfg.Args,
+		Env:        serverCfg.Env,
+		Extensions: serverCfg.Extensions,
 	}
 }
 

--- a/config.json.example
+++ b/config.json.example
@@ -14,6 +14,18 @@
       "env": {
         "VAR1": "$SERVER2_VAR1",
         "VAR2": "$SERVER2_VAR2"
+      },
+      "_extensions": {
+        "tools": {
+          "allow": [
+            "tool1",
+            "tool2"
+          ],
+          "deny": [
+            "tool11",
+            "tool12"
+          ]
+        }
       }
     }
   }

--- a/config.yml.example
+++ b/config.yml.example
@@ -13,3 +13,11 @@ mcpServers:
     env:
       VAR1: $SERVER2_VAR1
       VAR2: $SERVER2_VAR2
+    _extensions:
+      tools:
+        allow:
+          - tool1
+          - tool2
+        deny:
+          - tool11
+          - tool12

--- a/main.go
+++ b/main.go
@@ -15,9 +15,21 @@ import (
 
 // ServerConfig represents the MCP server configuration structure
 type ServerConfig struct {
-	Command string            `yaml:"command" json:"command"`
-	Args    []string          `yaml:"args" json:"args"`
-	Env     map[string]string `yaml:"env" json:"env"`
+	Command    string            `yaml:"command" json:"command"`
+	Args       []string          `yaml:"args" json:"args"`
+	Env        map[string]string `yaml:"env" json:"env"`
+	Extensions *Extensions       `yaml:"_extensions" json:"_extensions"`
+}
+
+// ToolsExtensions contains tool allow/deny lists
+type ToolsExtensions struct {
+	Allow []string `yaml:"allow" json:"allow"`
+	Deny  []string `yaml:"deny" json:"deny"`
+}
+
+// Extensions contains various extension configurations
+type Extensions struct {
+	Tools ToolsExtensions `yaml:"tools" json:"tools"`
 }
 
 // Config represents the application's global configuration structure

--- a/mcp_client_test.go
+++ b/mcp_client_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestIsToolAllowed(t *testing.T) {
+	tests := []struct {
+		name      string
+		client    *MCPClient
+		toolName  string
+		allowList []string
+		denyList  []string
+		expected  bool
+	}{
+		{
+			name:     "No extensions - should allow",
+			client:   &MCPClient{config: &MCPClientConfig{}},
+			toolName: "tool1",
+			expected: true,
+		},
+		{
+			name: "Empty allow and deny lists - should allow",
+			client: &MCPClient{
+				config: &MCPClientConfig{
+					Extensions: &Extensions{
+						Tools: ToolsExtensions{
+							Allow: []string{},
+							Deny:  []string{},
+						},
+					},
+				},
+			},
+			toolName: "tool1",
+			expected: true,
+		},
+		{
+			name: "Tool in allow list - should allow",
+			client: &MCPClient{
+				config: &MCPClientConfig{
+					Extensions: &Extensions{
+						Tools: ToolsExtensions{
+							Allow: []string{"tool1", "tool2"},
+							Deny:  []string{"tool3", "tool4"},
+						},
+					},
+				},
+			},
+			toolName: "tool1",
+			expected: true,
+		},
+		{
+			name: "Tool not in allow list - should deny",
+			client: &MCPClient{
+				config: &MCPClientConfig{
+					Extensions: &Extensions{
+						Tools: ToolsExtensions{
+							Allow: []string{"tool2", "tool3"},
+							Deny:  []string{},
+						},
+					},
+				},
+			},
+			toolName: "tool1",
+			expected: false,
+		},
+		{
+			name: "Tool in deny list, no allow list - should deny",
+			client: &MCPClient{
+				config: &MCPClientConfig{
+					Extensions: &Extensions{
+						Tools: ToolsExtensions{
+							Allow: []string{},
+							Deny:  []string{"tool1", "tool2"},
+						},
+					},
+				},
+			},
+			toolName: "tool1",
+			expected: false,
+		},
+		{
+			name: "Tool not in deny list, no allow list - should allow",
+			client: &MCPClient{
+				config: &MCPClientConfig{
+					Extensions: &Extensions{
+						Tools: ToolsExtensions{
+							Allow: []string{},
+							Deny:  []string{"tool2", "tool3"},
+						},
+					},
+				},
+			},
+			toolName: "tool1",
+			expected: true,
+		},
+		{
+			name: "Both allow and deny lists exist - allow list takes precedence",
+			client: &MCPClient{
+				config: &MCPClientConfig{
+					Extensions: &Extensions{
+						Tools: ToolsExtensions{
+							Allow: []string{"tool1", "tool2"},
+							Deny:  []string{"tool1", "tool3"},
+						},
+					},
+				},
+			},
+			toolName: "tool1",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.client.isToolAllowed(tt.toolName)
+			if result != tt.expected {
+				t.Errorf("isToolAllowed(%s) = %v, want %v", tt.toolName, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Added support for `_extensions` in `MCPClientConfig` and `ServerConfig` to manage tool allow/deny lists.
- Updated tests in `config_test.go` to validate loading configurations with extensions.
- Introduced `isToolAllowed` method in `MCPClient` to enforce tool access restrictions based on the defined allow/deny lists.
- Updated example configuration files to reflect new extensions structure.